### PR TITLE
Add S3 support for saving/loading FAISS

### DIFF
--- a/gwenflow/utils/aws.py
+++ b/gwenflow/utils/aws.py
@@ -1,3 +1,4 @@
+import io
 import os
 import json
 from collections import namedtuple
@@ -149,3 +150,39 @@ def aws_s3_uri_to_bucket_key(uri: str):
     except:
         pass
     return None, None
+
+def aws_s3_upload_fileobj(bucket: str, key: str, fileobj, content_type: str = "application/octet-stream"):
+    client = boto3.client('s3')
+    try:
+        client.upload_fileobj(Fileobj=fileobj,Bucket=bucket,Key=key,ExtraArgs={"ContentType": content_type})
+        return {
+            "success": True,
+            "bucket": bucket,
+            "key": key,
+            "content_type": content_type
+        }
+    except Exception as e:
+        return {
+            "success": False,
+            "error": str(e)
+        }
+    
+def aws_s3_download_in_buffer(bucket: str, key: str):
+    try:
+        client = boto3.client("s3")
+        buffer = io.BytesIO()
+        client.download_fileobj(Bucket=bucket, Key=key, Fileobj=buffer)
+        buffer.seek(0)
+        return buffer
+    except Exception as e:
+        print(f"Error downloading s3://{bucket}/{key}: {e}")
+        return None
+    
+def aws_s3_is_file(bucket: str, key: str) -> bool:
+    client = boto3.client('s3')
+    try:
+        client.head_object(Bucket=bucket, Key=key)
+        return True
+    except Exception:
+        return False
+


### PR DESCRIPTION

### Changes

- Detect `s3://` paths and handle save/load accordingly.
- Serialize full `faiss_data` (index + metadata) with `pickle` into an in-memory `BytesIO` buffer.
- Upload/download directly to/from S3 using `boto3`’s `upload_fileobj` and `download_fileobj` with buffers, avoiding temp files.
- Added `aws_s3_is_file` to check S3 object existence, enabling proper `exists()` handling for local vs S3 paths.

### Why

- FAISS indexes are large binary files; `upload_fileobj` is more efficient than `put_object`.
- Using in-memory buffers avoids disk I/O overhead and complexity.
