### PR TITLE
Add system prompt to agent

### DIFF
--- a/gwenflow/agents/agent.py
+++ b/gwenflow/agents/agent.py
@@ -33,6 +33,9 @@ class Agent(BaseModel):
     description: str | None = None
     """A description of the agent, used as a handoff, so that the manager knows what it does."""
 
+    system_prompt: str | None = None
+    """"System prompt"""
+
     instructions: (str | List[str] | None) = None
     """The instructions for the agent."""
 
@@ -103,6 +106,8 @@ class Agent(BaseModel):
     
     def get_system_prompt(self, task: str, context: Optional[Union[str, Dict[str, str]]] = None,) -> str:
         """Get the system prompt for the agent."""
+        if self.system_prompt:
+            return self.system_prompt
 
         prompt = "Your name is {name}.".format(name=self.name)
 


### PR DESCRIPTION
This pull request introduces enhancements to the `Agent` class in `gwenflow/agents/agent.py`, focusing on adding support for a customizable `system_prompt` attribute and improving the logic for generating system prompts. 

### Enhancements to `Agent` class:

* **Added `system_prompt` attribute**: Introduced a new `system_prompt` attribute to the `Agent` class, allowing agents to have a predefined system prompt. This adds flexibility for customizing agent behavior. (`[gwenflow/agents/agent.pyR36-R38](diffhunk://#diff-3dc5de3c7284f24db1b821ff6db5720cbfb94334c31c09d8aceb188b29b98ab3R36-R38)`)
* **Updated `get_system_prompt` method**: Modified the `get_system_prompt` method to prioritize returning the `system_prompt` attribute if it is defined, simplifying the prompt generation logic. (`[gwenflow/agents/agent.pyR109-R110](diffhunk://#diff-3dc5de3c7284f24db1b821ff6db5720cbfb94334c31c09d8aceb188b29b98ab3R109-R110)`)