### PR TITLE
Add excel and pptx reader

### DIFF
--- a/gwenflow/readers/__init__.py
+++ b/gwenflow/readers/__init__.py
@@ -1,3 +1,4 @@
+from gwenflow.readers.csv import CSVReader
 from gwenflow.readers.directory import SimpleDirectoryReader
 from gwenflow.readers.docx import DocxReader
 from gwenflow.readers.excel import ExcelReader
@@ -6,4 +7,4 @@ from gwenflow.readers.pdf import PDFReader
 from gwenflow.readers.text import TextReader
 from gwenflow.readers.website import WebsiteReader
 
-__all__ = ["SimpleDirectoryReader", "TextReader", "JSONReader", "PDFReader", "WebsiteReader", "DocxReader", "ExcelReader"]
+__all__ = ["SimpleDirectoryReader", "TextReader", "JSONReader", "PDFReader", "WebsiteReader", "DocxReader", "ExcelReader", "CSVReader"]

--- a/gwenflow/readers/__init__.py
+++ b/gwenflow/readers/__init__.py
@@ -4,7 +4,8 @@ from gwenflow.readers.docx import DocxReader
 from gwenflow.readers.excel import ExcelReader
 from gwenflow.readers.json import JSONReader
 from gwenflow.readers.pdf import PDFReader
+from gwenflow.readers.pptx import PptxReader
 from gwenflow.readers.text import TextReader
 from gwenflow.readers.website import WebsiteReader
 
-__all__ = ["SimpleDirectoryReader", "TextReader", "JSONReader", "PDFReader", "WebsiteReader", "DocxReader", "ExcelReader", "CSVReader"]
+__all__ = ["SimpleDirectoryReader", "TextReader", "JSONReader", "PDFReader", "WebsiteReader", "DocxReader", "ExcelReader", "CSVReader", "PptxReader"]

--- a/gwenflow/readers/__init__.py
+++ b/gwenflow/readers/__init__.py
@@ -1,8 +1,9 @@
 from gwenflow.readers.directory import SimpleDirectoryReader
 from gwenflow.readers.docx import DocxReader
+from gwenflow.readers.excel import ExcelReader
 from gwenflow.readers.json import JSONReader
 from gwenflow.readers.pdf import PDFReader
 from gwenflow.readers.text import TextReader
 from gwenflow.readers.website import WebsiteReader
 
-__all__ = ["SimpleDirectoryReader", "TextReader", "JSONReader", "PDFReader", "WebsiteReader", "DocxReader"]
+__all__ = ["SimpleDirectoryReader", "TextReader", "JSONReader", "PDFReader", "WebsiteReader", "DocxReader", "ExcelReader"]

--- a/gwenflow/readers/csv.py
+++ b/gwenflow/readers/csv.py
@@ -9,13 +9,13 @@ from gwenflow.readers.base import Reader
 from gwenflow.types import Document
 
 
-class ExcelReader(Reader):
+class CSVReader(Reader):
 
     @model_validator(mode="before")
     @classmethod
     def validate_environment(cls, values: Any) -> Any:
         missing = []
-        for package in ("pandas", "openpyxl", "tabulate"):
+        for package in ("pandas", "tabulate"):
             try:
                 __import__(package)
             except ImportError:
@@ -30,29 +30,26 @@ class ExcelReader(Reader):
     def read(
         self,
         file: Union[Path, io.BytesIO],
-        sheet_name: Optional[str] = None,
+        sep: str = ",",
+        decimal: str = ".",
         max_rows: Optional[int] = None,
     ) -> List[Document]:
         import pandas as pd
 
         try:
             filename = self.get_file_name(file)
-            content = self.get_file_content(file)
-            xls = pd.ExcelFile(content)
-            sheet_names = [sheet_name] if sheet_name is not None else xls.sheet_names
-            documents = []
-            for page_num, sheet in enumerate(sheet_names, start=1):
-                df = pd.read_excel(xls, sheet_name=sheet)
-                truncated = max_rows is not None and len(df) > max_rows
-                display_df = df.head(max_rows) if truncated else df
-                documents.append(
-                    Document(
-                        id=self.key(f"{filename}_{sheet}"),
-                        content=display_df.to_markdown(index=False),
-                        metadata={"filename": filename, "sheet": sheet, "page": page_num, "rows": len(df), "columns": list(df.columns), "truncated": truncated},
-                    )
+            text_content = self.get_file_content(file, text_mode=True)
+            source = io.StringIO(text_content) if isinstance(text_content, str) else text_content
+            df = pd.read_csv(source, sep=sep, decimal=decimal)
+            truncated = max_rows is not None and len(df) > max_rows
+            display_df = df.head(max_rows) if truncated else df
+            return [
+                Document(
+                    id=self.key(filename),
+                    content=display_df.to_markdown(index=False),
+                    metadata={"filename": filename, "rows": len(df), "columns": list(df.columns), "truncated": truncated},
                 )
-            return documents
+            ]
         except Exception as e:
             logger.exception(f"Error reading file: {e}")
             return []

--- a/gwenflow/readers/excel.py
+++ b/gwenflow/readers/excel.py
@@ -1,0 +1,84 @@
+import io
+from pathlib import Path
+from typing import Any, List, Optional, Union
+
+from pydantic import model_validator
+
+from gwenflow.logger import logger
+from gwenflow.readers.base import Reader
+from gwenflow.types import Document
+
+
+class ExcelReader(Reader):
+    sheet_name: Union[str, None] = None
+    sep: str = ","
+    decimal: str = "."
+    max_rows: Optional[int] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_environment(cls, values: Any) -> Any:
+        try:
+            import pandas # noqa: F401
+        except ImportError:
+            raise ImportError("`pandas` is not installed. Please install it with `uv add pandas`.")
+        try:
+            import openpyxl # noqa: F401
+        except ImportError:
+            raise ImportError("`openpyxl` is not installed. Please install it with `uv add openpyxl`.")
+        try:
+            import tabulate # noqa: F401
+        except ImportError:
+            raise ImportError("`tabulate` is not installed. Please install it with `uv add tabulate`.")
+        return values
+
+    def _df_to_text(self, df) -> str:
+        if self.max_rows is not None and len(df) > self.max_rows:
+            df = df.head(self.max_rows)
+        return df.to_markdown(index=False)
+
+    def read(self, file: Union[Path, io.BytesIO]) -> List[Document]:
+        import pandas as pd
+        try:
+            filename = self.get_file_name(file)
+
+            name = filename.lower() if isinstance(filename, str) else ""
+            is_csv = name.endswith(".csv")
+
+            documents = []
+
+            if is_csv:
+                text_content = self.get_file_content(file, text_mode=True)
+                df = pd.read_csv(io.StringIO(text_content) if isinstance(text_content, str) else text_content, sep=self.sep, decimal=self.decimal)
+                documents.append(
+                    Document(
+                        id=self.key(f"{filename}"),
+                        content=self._df_to_text(df),
+                        metadata={"filename": filename, "rows": len(df), "columns": list(df.columns)},
+                    )
+                )
+            else:
+                content = self.get_file_content(file)
+                xls = pd.ExcelFile(content)
+                sheet_names = [self.sheet_name] if self.sheet_name is not None else xls.sheet_names
+                for page_num, sheet in enumerate(sheet_names, start=1):
+                    df = pd.read_excel(xls, sheet_name=sheet)
+                    documents.append(
+                        Document(
+                            id=self.key(f"{filename}_{sheet}"),
+                            content=self._df_to_text(df),
+                            metadata={
+                                "filename": filename,
+                                "sheet": sheet,
+                                "page": page_num,
+                                "rows": len(df),
+                                "columns": list(df.columns),
+                            },
+                        )
+                    )
+
+        except Exception as e:
+            logger.exception(f"Error reading file: {e}")
+            return []
+
+        return documents

--- a/gwenflow/readers/excel.py
+++ b/gwenflow/readers/excel.py
@@ -18,67 +18,57 @@ class ExcelReader(Reader):
     @model_validator(mode="before")
     @classmethod
     def validate_environment(cls, values: Any) -> Any:
-        try:
-            import pandas # noqa: F401
-        except ImportError:
-            raise ImportError("`pandas` is not installed. Please install it with `uv add pandas`.")
-        try:
-            import openpyxl # noqa: F401
-        except ImportError:
-            raise ImportError("`openpyxl` is not installed. Please install it with `uv add openpyxl`.")
-        try:
-            import tabulate # noqa: F401
-        except ImportError:
-            raise ImportError("`tabulate` is not installed. Please install it with `uv add tabulate`.")
+        missing = []
+        for package in ("pandas", "openpyxl", "tabulate"):
+            try:
+                __import__(package)
+            except ImportError:
+                missing.append(package)
+        if missing:
+            raise ImportError(
+                f"Missing required packages: {', '.join(missing)}. "
+                f"Install with: `uv add {' '.join(missing)}`"
+            )
         return values
 
-    def _df_to_text(self, df) -> str:
-        if self.max_rows is not None and len(df) > self.max_rows:
-            df = df.head(self.max_rows)
-        return df.to_markdown(index=False)
+    def _build_document(self, df: Any, id: str, **metadata) -> Document:
+        truncated = self.max_rows is not None and len(df) > self.max_rows
+        display_df = df.head(self.max_rows) if truncated else df
+        return Document(
+            id=id,
+            content=display_df.to_markdown(index=False),
+            metadata={**metadata, "rows": len(df), "columns": list(df.columns), "truncated": truncated},
+        )
+
+    def _read_csv(self, file: Union[Path, io.BytesIO], filename: str) -> List[Document]:
+        import pandas as pd
+        text_content = self.get_file_content(file, text_mode=True)
+        source = io.StringIO(text_content) if isinstance(text_content, str) else text_content
+        df = pd.read_csv(source, sep=self.sep, decimal=self.decimal)
+        return [self._build_document(df, id=self.key(filename), filename=filename)]
+
+    def _read_excel(self, file: Union[Path, io.BytesIO], filename: str) -> List[Document]:
+        import pandas as pd
+        content = self.get_file_content(file)
+        xls = pd.ExcelFile(content)
+        sheet_names = [self.sheet_name] if self.sheet_name is not None else xls.sheet_names
+        documents = []
+        for page_num, sheet in enumerate(sheet_names, start=1):
+            df = pd.read_excel(xls, sheet_name=sheet)
+            documents.append(self._build_document(
+                df,
+                id=self.key(f"{filename}_{sheet}"),
+                filename=filename,
+                sheet=sheet,
+                page=page_num,
+            ))
+        return documents
 
     def read(self, file: Union[Path, io.BytesIO]) -> List[Document]:
-        import pandas as pd
         try:
             filename = self.get_file_name(file)
-
-            name = filename.lower() if isinstance(filename, str) else ""
-            is_csv = name.endswith(".csv")
-
-            documents = []
-
-            if is_csv:
-                text_content = self.get_file_content(file, text_mode=True)
-                df = pd.read_csv(io.StringIO(text_content) if isinstance(text_content, str) else text_content, sep=self.sep, decimal=self.decimal)
-                documents.append(
-                    Document(
-                        id=self.key(f"{filename}"),
-                        content=self._df_to_text(df),
-                        metadata={"filename": filename, "rows": len(df), "columns": list(df.columns)},
-                    )
-                )
-            else:
-                content = self.get_file_content(file)
-                xls = pd.ExcelFile(content)
-                sheet_names = [self.sheet_name] if self.sheet_name is not None else xls.sheet_names
-                for page_num, sheet in enumerate(sheet_names, start=1):
-                    df = pd.read_excel(xls, sheet_name=sheet)
-                    documents.append(
-                        Document(
-                            id=self.key(f"{filename}_{sheet}"),
-                            content=self._df_to_text(df),
-                            metadata={
-                                "filename": filename,
-                                "sheet": sheet,
-                                "page": page_num,
-                                "rows": len(df),
-                                "columns": list(df.columns),
-                            },
-                        )
-                    )
-
+            is_csv = isinstance(filename, str) and filename.lower().endswith(".csv")
+            return self._read_csv(file, filename) if is_csv else self._read_excel(file, filename)
         except Exception as e:
             logger.exception(f"Error reading file: {e}")
             return []
-
-        return documents

--- a/gwenflow/readers/pptx.py
+++ b/gwenflow/readers/pptx.py
@@ -1,0 +1,57 @@
+import io
+from pathlib import Path
+from typing import Any, List, Union
+
+from pydantic import model_validator
+
+from gwenflow.logger import logger
+from gwenflow.readers.base import Reader
+from gwenflow.types import Document
+
+
+class PptxReader(Reader):
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_environment(cls, values: Any) -> Any:
+        try:
+            __import__("pptx")
+        except ImportError:
+            raise ImportError(
+                "Missing required package: python-pptx. "
+                "Install with: `uv add python-pptx`"
+            )
+        return values
+
+    def read(
+        self,
+        file: Union[Path, io.BytesIO],
+    ) -> List[Document]:
+        from pptx import Presentation
+
+        try:
+            filename = self.get_file_name(file)
+            content = self.get_file_content(file)
+            prs = Presentation(content)
+            documents = []
+            for slide_num, slide in enumerate(prs.slides, start=1):
+                texts = []
+                for shape in slide.shapes:
+                    if not shape.has_text_frame:
+                        continue
+                    for para in shape.text_frame.paragraphs:
+                        line = "".join(run.text for run in para.runs).strip()
+                        if line:
+                            texts.append(line)
+                slide_text = "\n".join(texts)
+                documents.append(
+                    Document(
+                        id=self.key(f"{filename}_slide{slide_num}"),
+                        content=slide_text,
+                        metadata={"filename": filename, "page": slide_num, "slide": slide_num},
+                    )
+                )
+            return documents
+        except Exception as e:
+            logger.exception(f"Error reading file: {e}")
+            return []


### PR DESCRIPTION
Ajout d'un excel reader : target un .csv ou .xlsx
Arguments: 

- sheet_name si .xlsx et besoin de specifier un nom de feuille
- sep, decimal: arguments des csv de base
- max_rows: si besoin de contraindre le tool facilement


Tests:
```python from gwenflow.readers.csv import CSVReader
from gwenflow.readers.excel import ExcelReader
from pathlib import Path

file = Path("internal_tests/data/test.xlsx")
reader = ExcelReader()
print(reader.read(file=file))

file = Path("internal_tests/data/test.csv")
reader = CSVReader()
print(reader.read(file=file))
```