### PR TITLE
Handle tool calls with empty arguments

### DIFF
--- a/gwenflow/agents/agent.py
+++ b/gwenflow/agents/agent.py
@@ -321,7 +321,7 @@ class Agent:
             try:
                 args = tool_call.arguments
                 if not isinstance(args, dict):
-                    args = json.loads(args)
+                    args = json.loads(args) if args and args.strip() else {}
                 skill_name = args.get("skill_name")
                 logger.debug(f"[SKILL CALL] Loading skill '{skill_name}'")
                 skill = next((s for s in self.skills if s.name == skill_name), None)
@@ -335,7 +335,7 @@ class Agent:
             tool = tool_map[tool_call.name]
             arguments = tool_call.arguments
             if not isinstance(arguments, dict):
-                arguments = json.loads(arguments)
+                arguments = json.loads(arguments) if arguments and arguments.strip() else {}
             logger.info(f"[Tool Call] '{tool_call.name}'({arguments})")
             tool_execution.content = tool.run(**arguments)
             if tool_execution.content:
@@ -468,7 +468,7 @@ class Agent:
                 for tool_call in response.tool_calls:
                     args = tool_call.arguments
                     if not isinstance(args, dict):
-                        args = json.loads(args)
+                        args = json.loads(args) if args and args.strip() else {}
                     agent_response.events.append(
                         AgentEventToolStarted(
                             agent_id=self.id,
@@ -600,7 +600,7 @@ class Agent:
                 for tool_call in response.tool_calls:
                     args = tool_call.arguments
                     if not isinstance(args, dict):
-                        args = json.loads(args)
+                        args = json.loads(args) if args and args.strip() else {}
                     agent_response.events.append(
                         AgentEventToolStarted(
                             agent_id=self.id,
@@ -736,7 +736,7 @@ class Agent:
                 for tool_call in final_tool_calls:
                     args = tool_call.arguments
                     if not isinstance(args, dict):
-                        args = json.loads(args)
+                        args = json.loads(args) if args and args.strip() else {}
                     event = AgentEventToolStarted(
                         agent_id=self.id,
                         run_id=agent_response.run_id,
@@ -873,7 +873,7 @@ class Agent:
                 for tool_call in final_tool_calls:
                     args = tool_call.arguments
                     if not isinstance(args, dict):
-                        args = json.loads(args)
+                        args = json.loads(args) if args and args.strip() else {}
                     event = AgentEventToolStarted(
                         agent_id=self.id,
                         run_id=agent_response.run_id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gwenflow"
-version = "1.0.3"
+version = "1.0.4"
 description = "A framework for orchestrating applications powered by autonomous AI agents and LLMs."
 readme = "README.md"
 requires-python = ">=3.11,<3.14"


### PR DESCRIPTION
## Summary
- Handle tool calls whose `arguments` is an empty or whitespace-only string: fall back to `{}` instead of crashing in `json.loads` (applies to skill calls, tool dispatch, and streamed tool events in `gwenflow/agents/agent.py`)
- Bump version to 1.0.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)