### PR TITLE
Fix chat memory buffer dropping the user task mid-run

### DIFF
--- a/gwenflow/agents/agent.py
+++ b/gwenflow/agents/agent.py
@@ -171,6 +171,39 @@ class Agent:
             )
             return False, None, error_msg
 
+    def _tools_token_count(self) -> int:
+        """Tokens the tool schemas cost on the wire.
+
+        Every provider sends the same three fields per tool (name, description,
+        JSON-schema parameters), so a single neutral estimate covers them all.
+        These tokens never appear in the message list, so the memory buffer has
+        to be told to reserve them — a large MCP server can otherwise eat the
+        whole context margin without the buffer noticing.
+        """
+        tools = self.llm.tools or []
+        tokenizer_fn = self.history.tokenizer_fn
+        total = 0
+        for tool in tools:
+            schema = {
+                "name": tool.name,
+                "description": tool.description or "",
+                "parameters": tool.parameters,
+            }
+            total += tokenizer_fn(json.dumps(schema, default=str))
+        return total
+
+    def _prepare_history(
+        self,
+        task: str,
+        context: Optional[Union[str, Dict[str, str]]] = None,
+    ) -> None:
+        """Refresh the parts of the memory budget that are settled per run.
+
+        The system prompt and the tool schemas sent alongside every request.
+        """
+        self.history.system_prompt = self.get_system_prompt(task=task, context=context)
+        self.history.reserved_tokens = self._tools_token_count()
+
     def get_system_prompt(
         self,
         task: str,
@@ -386,7 +419,7 @@ class Agent:
         )
 
         # history
-        self.history.system_prompt = self.get_system_prompt(task=task, context=context)
+        self._prepare_history(task=task, context=context)
         self.history.add_messages(messages)
 
         # add reasoning
@@ -524,7 +557,7 @@ class Agent:
             )
         )
 
-        self.history.system_prompt = self.get_system_prompt(task=task, context=context)
+        self._prepare_history(task=task, context=context)
         self.history.add_messages(messages)
 
         if self.reasoning_model:
@@ -656,7 +689,7 @@ class Agent:
         agent_response.events.append(event)
         yield event
 
-        self.history.system_prompt = self.get_system_prompt(task=task, context=context)
+        self._prepare_history(task=task, context=context)
         self.history.add_messages(messages)
 
         if self.reasoning_model:
@@ -796,7 +829,7 @@ class Agent:
         agent_response.events.append(event)
         yield event
 
-        self.history.system_prompt = self.get_system_prompt(task=task, context=context)
+        self._prepare_history(task=task, context=context)
         self.history.add_messages(messages)
 
         if self.reasoning_model:

--- a/gwenflow/memory/base.py
+++ b/gwenflow/memory/base.py
@@ -61,7 +61,7 @@ class BaseChatMemory:
         if isinstance(part, TextContent):
             return self.tokenizer_fn(part.content)
         if isinstance(part, ThinkingContent):
-            return self.tokenizer_fn(part.content)
+            return self._token_count_for_thinking(part)
         if isinstance(part, ImageContent):
             return IMAGE_TOKENS_HIGH if part.detail == "high" else IMAGE_TOKENS_LOW
         if isinstance(part, AudioContent):
@@ -80,13 +80,29 @@ class BaseChatMemory:
             return self.tokenizer_fn(json.dumps(part))
         return self.tokenizer_fn(str(part))
 
+    def _token_count_for_thinking(self, part: ThinkingContent) -> int:
+        """Estimate tokens for one thinking part, `extra` included.
+
+        Anthropic's block signature lives in `extra` and is echoed back verbatim
+        on tool-use turns — it is a large base64 blob, not free.
+        """
+        total = self.tokenizer_fn(part.content)
+        if part.extra:
+            total += self.tokenizer_fn(json.dumps(part.extra, default=str))
+        return total
+
     def _token_count_for_message(self, m: Message) -> int:
-        """Estimate tokens for an entire Message, including all fields the
-        provider will end up sending: content (string or parts), tool_calls,
-        thinking_parts, and the small per-message envelope (role/name)."""
+        """Estimate tokens for an entire Message.
+
+        Includes every field the provider will end up sending: content (string
+        or parts), tool_calls, tool_call_id, thinking_parts, and the small
+        per-message envelope (role/name).
+        """
         total = 4  # role + envelope overhead
         if m.name:
             total += self.tokenizer_fn(m.name)
+        if m.tool_call_id:
+            total += self.tokenizer_fn(m.tool_call_id)
         if isinstance(m.content, list):
             for part in m.content:
                 total += self._token_count_for_part(part)
@@ -97,7 +113,7 @@ class BaseChatMemory:
                 total += self.tokenizer_fn(json.dumps(tc, default=str))
         if m.thinking_parts:
             for tp in m.thinking_parts:
-                total += self.tokenizer_fn(tp.content)
+                total += self._token_count_for_thinking(tp)
         return total
 
     def _token_count_for_messages(self, messages: list[Message]) -> int:

--- a/gwenflow/memory/chat_memory_buffer.py
+++ b/gwenflow/memory/chat_memory_buffer.py
@@ -15,18 +15,30 @@ MAX_MESSAGE_CONTENT = 0.5
 class ChatMemoryBuffer(BaseChatMemory):
     """Sliding-window memory that keeps the most recent messages within a token budget.
 
-    Two-pass strategy:
+    Three-pass strategy:
       1. Pre-filter: any single message exceeding `MAX_MESSAGE_CONTENT * token_limit`
          has its TEXT parts truncated. Multi-modal parts (image/audio/file) and
          thinking_parts are left intact — clamping them would corrupt the wire
          format. If a single message remains over budget after truncation, we
          accept it and let the prune loop drop older messages.
-      2. Prune: drop oldest messages until total tokens fit. Never starts the
-         kept window with a `tool` message (orphan response) or with an
-         `assistant` message whose tool_calls would lose their responses.
+      2. Prune: keep the longest suffix of the history that fits the budget.
+      3. Anchor: the live turn — the last `user` message — is always kept, even
+         when the suffix that fits no longer reaches it (a long tool loop can
+         easily blow the budget on its own). Without this the model would be
+         called with a system prompt and no task at all. When the turn overflows,
+         its oldest messages are dropped instead of the user question.
+
+    The window never starts on a `tool` message: its `tool_calls` parent would
+    have been pruned, leaving an orphan response the providers reject.
     """
 
     token_limit: int | None = None
+
+    reserved_tokens: int = 0
+    """Tokens the request spends outside the message list — the tool schemas the
+    provider sends alongside every call. Not knowing about them made the buffer
+    believe it was under budget while the request overflowed. The agent refreshes
+    this at the start of each run."""
 
     def __post_init__(self) -> None:
         super().__post_init__()
@@ -41,8 +53,9 @@ class ChatMemoryBuffer(BaseChatMemory):
         """Truncate the TEXT portion of a message in place to fit `max_tokens`.
 
         Multi-modal parts, tool_calls, and thinking_parts are preserved as-is —
-        we only shrink free-form text. If content is a list of parts, only
-        TextContent items are clamped (each independently to the same budget).
+        we only shrink free-form text. If content is a list of parts, the budget
+        is split evenly across the TextContent items so that a message with many
+        text parts still lands under `max_tokens`.
         """
         if isinstance(message.content, str):
             message.content = keep_tokens_from_text(
@@ -51,12 +64,14 @@ class ChatMemoryBuffer(BaseChatMemory):
                 tokenizer_fn=self.tokenizer_fn,
             )
         elif isinstance(message.content, list):
+            text_parts = sum(1 for p in message.content if isinstance(p, TextContent))
+            per_part_limit = max_tokens // text_parts if text_parts else max_tokens
             new_parts: list[Any] = []
             for p in message.content:
                 if isinstance(p, TextContent):
                     clamped = keep_tokens_from_text(
                         p.content,
-                        token_limit=max_tokens,
+                        token_limit=per_part_limit,
                         tokenizer_fn=self.tokenizer_fn,
                     )
                     new_parts.append(TextContent(content=clamped))
@@ -65,6 +80,13 @@ class ChatMemoryBuffer(BaseChatMemory):
             message.content = new_parts
         # If content is None, nothing to clamp (the message might be an
         # assistant turn carrying only tool_calls — leave it alone).
+
+    def _last_user_index(self, chat_history: list[Message]) -> int | None:
+        """Index of the most recent `user` message — the start of the live turn."""
+        for index in range(len(chat_history) - 1, -1, -1):
+            if chat_history[index].role == "user":
+                return index
+        return None
 
     def _initial_token_count(self) -> int:
         if not self.system_prompt:
@@ -89,29 +111,56 @@ class ChatMemoryBuffer(BaseChatMemory):
         if not chat_history:
             return self._prepend_system([])
 
-        # Pass 1: clamp very large individual messages (text-only effect)
-        per_message_limit = int(MAX_MESSAGE_CONTENT * self.token_limit)
-        for index in range(len(chat_history)):
-            if self._token_count_for_message(chat_history[index]) > per_message_limit:
-                self._clamp_message_text(chat_history[index], max_tokens=per_message_limit)
-
-        # Pass 2: drop oldest until under budget, keeping tool/assistant chains intact
-        keep = len(chat_history)
-        token_count = self._token_count_for_messages(chat_history) + initial_token_count
-
-        while token_count > self.token_limit and keep > 0:
-            keep -= 1
-            # Don't start the kept window with an orphan tool/assistant
-            while keep > 0 and chat_history[-keep].role in ("tool", "assistant"):
-                keep -= 1
-            if keep == 0:
-                break
-            token_count = (
-                self._token_count_for_messages(chat_history[-keep:]) + initial_token_count
+        budget = self.token_limit - initial_token_count - self.reserved_tokens
+        if budget <= 0:
+            logger.warning(
+                f"System prompt and tool schemas fill the whole context "
+                f"({initial_token_count + self.reserved_tokens} of {self.token_limit} tokens): "
+                f"no room left for the conversation."
             )
+            budget = 0
 
-        if token_count > self.token_limit:
-            logger.warning("Token limit exceeded.")
-            return self._prepend_system([])
+        # Pass 1: clamp very large individual messages (text-only effect)
+        per_message_limit = int(MAX_MESSAGE_CONTENT * budget)
+        for message in chat_history:
+            if self._token_count_for_message(message) > per_message_limit:
+                self._clamp_message_text(message, max_tokens=per_message_limit)
 
-        return self._prepend_system(chat_history[-keep:] if keep > 0 else [])
+        counts = [self._token_count_for_message(m) for m in chat_history]
+
+        # Pass 2: keep the longest suffix that fits the budget
+        start = len(chat_history)
+        token_count = 0
+        for index in range(len(chat_history) - 1, -1, -1):
+            if token_count + counts[index] > budget:
+                break
+            token_count += counts[index]
+            start = index
+
+        # Pass 3: never drop the live turn. If the suffix that fits stops short of
+        # the last user message, pull that message back in and drop the oldest
+        # messages of the turn instead — a task-less prompt is worse than a
+        # truncated one.
+        anchor = self._last_user_index(chat_history)
+        if anchor is not None and start > anchor:
+            token_count += counts[anchor]
+            while token_count > budget and start < len(chat_history) - 1:
+                token_count -= counts[start]
+                start += 1
+
+        # An orphan `tool` message (its `tool_calls` parent was pruned) is
+        # rejected by the providers: skip forward past any leading one.
+        while start < len(chat_history) and chat_history[start].role == "tool":
+            token_count -= counts[start]
+            start += 1
+
+        kept = chat_history[start:]
+        if anchor is not None and anchor < start:
+            kept = [chat_history[anchor]] + kept
+
+        if not kept:
+            logger.warning("Token limit exceeded: no message left to send.")
+        elif token_count > budget:
+            logger.warning(f"Token limit exceeded: sending the current turn anyway ({token_count} > {budget} tokens).")
+
+        return self._prepend_system(kept)

--- a/gwenflow/utils/tokens.py
+++ b/gwenflow/utils/tokens.py
@@ -56,11 +56,22 @@ def num_tokens_from_messages(messages, model="gpt-3.5-turbo-0613"):
 
 
 def keep_tokens_from_text(text: str, token_limit: int, tokenizer_fn: callable) -> str:
-    num_tokens = 0
-    truncated_text = []
-    for token in text.split(" "):
-        num_tokens = tokenizer_fn(" ".join(truncated_text))
-        if num_tokens > token_limit:
-            break
-        truncated_text.append(token)
-    return " ".join(truncated_text)
+    """Return the longest word-boundary prefix of `text` fitting `token_limit`.
+
+    Binary search on the word count: tokenizing once per word is quadratic and
+    takes over 30s on a large document, which stalls every agent turn.
+    """
+    if token_limit <= 0 or not text:
+        return ""
+    if tokenizer_fn(text) <= token_limit:
+        return text
+
+    words = text.split(" ")
+    low, high = 0, len(words)  # `low` always fits, `high` never does
+    while high - low > 1:
+        mid = (low + high) // 2
+        if tokenizer_fn(" ".join(words[:mid])) <= token_limit:
+            low = mid
+        else:
+            high = mid
+    return " ".join(words[:low])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gwenflow"
-version = "1.0.5"
+version = "1.0.6"
 description = "A framework for orchestrating applications powered by autonomous AI agents and LLMs."
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import BaseModel
 
 from gwenflow.agents.agent import Agent
+from gwenflow.llms.base import ChatBase
 from gwenflow.tools import BaseTool
 from gwenflow.types import ModelResponse, RequestUsage, TextContent, ToolCall
 
@@ -284,3 +285,149 @@ def test_agent_run_real_api():
     assert result.content is not None
     assert result.finish_reason == "stop"
     assert result.usage.input_tokens > 0
+
+
+# ---------------------------------------------------------------------------
+# Memory budget: tool schemas
+# ---------------------------------------------------------------------------
+
+
+def test_tools_token_count_reserves_schema_budget():
+    agent = Agent(name="a", instructions="Be terse.", llm=_mock_llm([]), tools=[AddTool()])
+    assert agent._tools_token_count() > 0
+
+
+def test_tools_token_count_is_zero_without_tools():
+    agent = Agent(name="a", instructions="Be terse.", llm=_mock_llm([]))
+    assert agent._tools_token_count() == 0
+
+
+def test_prepare_history_sets_reserved_tokens():
+    agent = Agent(name="a", instructions="Be terse.", llm=_mock_llm([]), tools=[AddTool()])
+    assert agent.history.reserved_tokens == 0
+    agent._prepare_history(task="do something")
+    assert agent.history.reserved_tokens == agent._tools_token_count() > 0
+    assert agent.history.system_prompt
+
+
+# ---------------------------------------------------------------------------
+# Memory budget: end-to-end tool loop
+# ---------------------------------------------------------------------------
+
+
+@dataclass(kw_only=True)
+class BigSearchTool(BaseTool):
+    name: str = "search"
+    description: str = "Search the web for a query and return results."
+
+    def _run(self, query: str) -> str:
+        """Search the web.
+
+        Args:
+            query: what to look for.
+        """
+        return f"RESULTS for {query}: " + "lorem ipsum dolor sit amet " * 60
+
+
+def _capturing_llm(context_size, tool_turns):
+    """LLM that requests a tool call `tool_turns` times, recording each prompt."""
+    captured = []
+
+    def invoke(input=None, **kwargs):
+        captured.append(input)
+        n = len(captured)
+        if n <= tool_turns:
+            return ModelResponse(
+                parts=[ToolCall(id=f"call_{n}", name="search", arguments='{"query": "market ' + str(n) + '"}')],
+                finish_reason="tool_calls",
+                usage=RequestUsage(input_tokens=10, output_tokens=5),
+            )
+        return ModelResponse(
+            parts=[TextContent(content="final report")],
+            finish_reason="stop",
+            usage=RequestUsage(input_tokens=10, output_tokens=5),
+        )
+
+    llm = _mock_llm([])
+    llm.get_context_size.return_value = context_size
+    llm.invoke.side_effect = invoke
+    # A bare MagicMock returns an empty iterable here, so nothing would ever
+    # reach memory and the test would pass vacuously.
+    llm.input_to_message_list.side_effect = ChatBase.input_to_message_list.__get__(llm)
+    llm.get_thinking_parts.return_value = None
+    return llm, captured
+
+
+def test_tool_loop_never_sends_a_task_less_prompt():
+    """Every turn must carry the task, however long the tool loop runs.
+
+    Regression: once a tool loop overflowed the budget, every later turn was
+    sent to the model with nothing but a system prompt — the agent silently
+    kept running with no task and no tool results.
+    """
+    task = "Analyse the French cloud market and write a report."
+    llm, captured = _capturing_llm(context_size=1200, tool_turns=6)
+    agent = Agent(name="analyst", instructions="Be terse.", llm=llm, tools=[BigSearchTool()])
+
+    agent.run(task)
+
+    assert len(captured) == 7
+    for turn, messages in enumerate(captured, 1):
+        roles = [m["role"] for m in messages]
+        non_system = [r for r in roles if r != "system"]
+        assert non_system, f"turn {turn} was sent with only a system prompt: {roles}"
+        assert non_system[0] != "tool", f"turn {turn} opens on an orphan tool response: {roles}"
+        assert any(
+            task[:20] in str(m.get("content") or "") for m in messages
+        ), f"turn {turn} lost the user task: {roles}"
+
+
+def test_tool_loop_window_stays_bounded():
+    """The window must still slide — keeping everything would defeat the buffer."""
+    llm, captured = _capturing_llm(context_size=1200, tool_turns=6)
+    agent = Agent(name="analyst", instructions="Be terse.", llm=llm, tools=[BigSearchTool()])
+
+    agent.run("Analyse the French cloud market.")
+
+    # Without pruning the last turn would carry 1 user + 6*(assistant+tool) = 13 messages
+    assert len(captured[-1]) < 13
+
+
+def test_streaming_tool_loop_never_sends_a_task_less_prompt():
+    """Same regression on the streaming path.
+
+    The run didn't crash, it just started talking to a model that had been
+    given no task.
+    """
+    task = "Analyse the French cloud market and write a report."
+    captured = []
+
+    def stream(input=None, **kwargs):
+        captured.append(input)
+        n = len(captured)
+        if n <= 6:
+            yield ModelResponse(
+                parts=[ToolCall(id=f"call_{n}", name="search", arguments='{"query": "market ' + str(n) + '"}')],
+                finish_reason="tool_calls",
+                usage=RequestUsage(input_tokens=10, output_tokens=5),
+            )
+        else:
+            for word in ["final ", "report"]:
+                yield ModelResponse(parts=[TextContent(content=word)], usage=RequestUsage(output_tokens=1))
+
+    llm = _mock_llm([])
+    llm.get_context_size.return_value = 1200
+    llm.stream.side_effect = stream
+    llm.input_to_message_list.side_effect = ChatBase.input_to_message_list.__get__(llm)
+    llm.get_thinking_parts.return_value = None
+
+    agent = Agent(name="analyst", instructions="Be terse.", llm=llm, tools=[BigSearchTool()])
+    streamed = "".join(
+        e.content for e in agent.run_stream(task) if type(e).__name__ == "AgentEventContent" and e.content
+    )
+
+    assert streamed == "final report"
+    for turn, messages in enumerate(captured, 1):
+        non_system = [m["role"] for m in messages if m["role"] != "system"]
+        assert non_system, f"turn {turn} was streamed with only a system prompt"
+        assert any(task[:20] in str(m.get("content") or "") for m in messages), f"turn {turn} lost the user task"

--- a/tests/test_memory_buffer.py
+++ b/tests/test_memory_buffer.py
@@ -14,7 +14,6 @@ import pytest
 from gwenflow.memory import ChatMemoryBuffer
 from gwenflow.types import AudioContent, FileContent, ImageContent, Message, TextContent, ThinkingContent
 
-
 # ---------------------------------------------------------------------------
 # Token counting
 # ---------------------------------------------------------------------------
@@ -29,7 +28,8 @@ def test_token_count_string_content():
 
 def test_token_count_multimodal_image_does_not_count_repr():
     """Without the fix this would stringify a list to its Python repr and count
-    the class names — wildly inaccurate. We use a fixed per-image estimate."""
+    the class names — wildly inaccurate. We use a fixed per-image estimate.
+    """
     buf = ChatMemoryBuffer(token_limit=1000)
     m = Message(role="user", content=[TextContent(content="hi"), ImageContent.from_url("https://x/y.jpg")])
     n = buf._token_count_for_message(m)
@@ -71,7 +71,13 @@ def test_token_count_includes_tool_calls():
         Message(
             role="assistant",
             content="ok",
-            tool_calls=[{"id": "t1", "type": "function", "function": {"name": "get_weather", "arguments": '{"city": "Paris", "units": "metric"}'}}],
+            tool_calls=[
+                {
+                    "id": "t1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": '{"city": "Paris", "units": "metric"}'},
+                }
+            ],
         )
     )
     assert with_tool > plain
@@ -88,6 +94,25 @@ def test_token_count_includes_thinking_parts():
         )
     )
     assert with_thinking > plain
+
+
+def test_token_count_includes_thinking_signature():
+    """Anthropic echoes the block signature back verbatim on tool-use turns —
+    it's a big base64 blob and must be charged for, not counted as free.
+    """
+    buf = ChatMemoryBuffer(token_limit=10000)
+    thinking = ThinkingContent(content="hmm")
+    signed = ThinkingContent(content="hmm", extra={"signature": "ErUBCkYIBRgCKkDx" * 40})
+    plain = buf._token_count_for_message(Message(role="assistant", content="", thinking_parts=[thinking]))
+    with_sig = buf._token_count_for_message(Message(role="assistant", content="", thinking_parts=[signed]))
+    assert with_sig > plain + 100
+
+
+def test_token_count_includes_tool_call_id():
+    buf = ChatMemoryBuffer(token_limit=10000)
+    anonymous = buf._token_count_for_message(Message(role="assistant", content="42"))
+    tool_result = buf._token_count_for_message(Message(role="tool", tool_call_id="call_9pQ2sZk1xVn", content="42"))
+    assert tool_result > anonymous
 
 
 # ---------------------------------------------------------------------------
@@ -129,7 +154,8 @@ def test_clamp_preserves_multimodal_parts():
 
 def test_clamp_with_none_content_does_not_crash():
     """An assistant message can carry tool_calls and no content — clamping must
-    not blow up on None."""
+    not blow up on None.
+    """
     buf = ChatMemoryBuffer(token_limit=200)
     buf.add_message(Message(role="user", content="hi"))
     buf.add_message(
@@ -171,7 +197,8 @@ def test_pruning_drops_oldest():
 
 def test_pruning_does_not_start_with_orphan_tool():
     """When pruning, the kept window must never start with a `tool` message —
-    that would be an orphan response with no matching tool_call."""
+    that would be an orphan response with no matching tool_call.
+    """
     buf = ChatMemoryBuffer(token_limit=60)
     # Conversation: user → assistant(tool_call) → tool → assistant → ... repeated
     for i in range(10):
@@ -194,7 +221,8 @@ def test_pruning_does_not_start_with_orphan_tool():
 def test_pruning_bounded_with_only_assistant_and_tool():
     """Pathological input: all messages are assistant/tool, no user. The
     buggy old loop would index out of bounds. The fix should drop everything
-    and return only system (or empty)."""
+    and return only system (or empty).
+    """
     buf = ChatMemoryBuffer(token_limit=50, system_prompt="sys")
     for i in range(5):
         buf.add_message(Message(role="assistant", content=f"a{i} word " * 30))
@@ -207,6 +235,42 @@ def test_pruning_bounded_with_only_assistant_and_tool():
     else:
         # Real bound is: doesn't crash, returns a list
         assert isinstance(kept, list)
+
+
+def test_live_turn_survives_a_long_tool_loop():
+    """Regression: a tool loop that blows the budget used to prune the whole
+    window — including the user's question — leaving the model with nothing but
+    a system prompt.
+    """
+    buf = ChatMemoryBuffer(token_limit=300, system_prompt="You are a helpful agent.")
+    buf.add_message(Message(role="user", content="Analyse this market and write a report."))
+    for i in range(4):
+        buf.add_message(
+            Message(
+                role="assistant",
+                content="",
+                tool_calls=[{"id": f"t{i}", "type": "function", "function": {"name": "search", "arguments": "{}"}}],
+            )
+        )
+        buf.add_message(Message(role="tool", tool_call_id=f"t{i}", content=f"result {i} " * 40))
+
+    kept = buf.get()
+    roles = [m.role for m in kept]
+    assert "user" in roles, f"user question was pruned away: {roles}"
+    assert any("Analyse this market" in (m.content or "") for m in kept if m.role == "user")
+    # And the window still opens on a valid boundary
+    assert roles[0] == "system"
+    assert roles[1] == "user"
+
+
+def test_pruning_never_returns_system_only_when_a_user_message_exists():
+    """Whatever the budget pressure, a task must reach the model."""
+    buf = ChatMemoryBuffer(token_limit=120, system_prompt="sys")
+    for i in range(6):
+        buf.add_message(Message(role="user", content=f"question {i} " * 20))
+        buf.add_message(Message(role="assistant", content=f"answer {i} " * 20))
+    kept = buf.get()
+    assert any(m.role == "user" for m in kept)
 
 
 def test_pruning_keeps_recent_user_question_intact():
@@ -260,3 +324,74 @@ def test_empty_history_returns_only_system():
 def test_empty_history_no_system_returns_empty():
     buf = ChatMemoryBuffer(token_limit=1000)
     assert buf.get() == []
+
+
+# ---------------------------------------------------------------------------
+# Truncation helper
+# ---------------------------------------------------------------------------
+
+
+def test_keep_tokens_is_not_quadratic():
+    """Truncation must not be quadratic.
+
+    Regression: the old word-by-word loop re-tokenized the whole accumulated
+    prefix per word — 30s+ on a large document, stalling every agent turn.
+    """
+    import time
+
+    from gwenflow.utils.tokens import keep_tokens_from_text, num_tokens_from_string
+
+    text = "word " * 200_000
+    started = time.perf_counter()
+    out = keep_tokens_from_text(text, token_limit=1000, tokenizer_fn=num_tokens_from_string)
+    elapsed = time.perf_counter() - started
+
+    assert num_tokens_from_string(out) <= 1000
+    assert elapsed < 5, f"truncation took {elapsed:.1f}s"
+
+
+def test_keep_tokens_returns_text_unchanged_when_it_fits():
+    from gwenflow.utils.tokens import keep_tokens_from_text, num_tokens_from_string
+
+    text = "a short sentence"
+    assert keep_tokens_from_text(text, token_limit=1000, tokenizer_fn=num_tokens_from_string) == text
+
+
+# ---------------------------------------------------------------------------
+# Reserved tokens (tool schemas)
+# ---------------------------------------------------------------------------
+
+
+def _fill(buf, count=12):
+    for i in range(count):
+        buf.add_message(Message(role="user", content=f"question {i} " * 10))
+        buf.add_message(Message(role="assistant", content=f"answer {i} " * 10))
+
+
+def test_reserved_tokens_shrink_the_budget():
+    """Tool schemas ride along with every request but never appear in messages.
+
+    The buffer has to reserve room for them.
+    """
+    without = ChatMemoryBuffer(token_limit=1000, system_prompt="sys")
+    _fill(without)
+    with_tools = ChatMemoryBuffer(token_limit=1000, system_prompt="sys", reserved_tokens=600)
+    _fill(with_tools)
+
+    assert len(with_tools.get()) < len(without.get())
+
+
+def test_reserved_tokens_still_keep_the_user_question():
+    """Even when the schemas eat most of the context, the task must get through."""
+    buf = ChatMemoryBuffer(token_limit=1000, system_prompt="sys", reserved_tokens=950)
+    _fill(buf)
+    kept = buf.get()
+    assert any(m.role == "user" for m in kept)
+
+
+def test_reserved_tokens_larger_than_limit_does_not_crash():
+    buf = ChatMemoryBuffer(token_limit=500, system_prompt="sys", reserved_tokens=5000)
+    buf.add_message(Message(role="user", content="hello"))
+    kept = buf.get()
+    assert isinstance(kept, list)
+    assert any(m.role == "user" for m in kept)

--- a/uv.lock
+++ b/uv.lock
@@ -533,7 +533,7 @@ wheels = [
 
 [[package]]
 name = "gwenflow"
-version = "1.0.5"
+version = "1.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## The bug

`ChatMemoryBuffer.get()` prune loop skipped forward past every `assistant`/`tool` message once the budget was exceeded:

```python
while keep > 0 and chat_history[-keep].role in ("tool", "assistant"):
    keep -= 1
```

In an agentic tool loop the tail after the user question is *entirely* assistant/tool messages, so this walked right past the question itself down to `keep == 0`.

**The agent didn't crash.** It kept running, calling the model with nothing but a system prompt — no task, no tool results — and returned a confidently hallucinated answer. Or the provider rejected the empty message list and the stream cut off mid-answer.

Captured from a real `Agent.run()` (6 tool turns, 1200-token context), showing what actually reached the LLM:

| turn | before | after |
|---|---|---|
| 1–4 | `system, user, assistant, tool…` ✅ | same ✅ |
| 5 | **`system` only** ❌ | `system, user, assistant, tool ×3` ✅ |
| 6 | **`system` only** ❌ | ✅ |
| 7 | **`system` only** ❌ | ✅ |

Identical on `run_stream()`.

## Changes

**Pruning rewritten** — keep the longest suffix that fits, then *anchor* the live turn (last `user` message) so it can never be dropped. When the turn itself overflows, its oldest messages go instead of the question. The window still never opens on an orphan `tool` response. It still slides (caps at 8 messages in the run above), it just no longer collapses.

**Quadratic truncation fixed** — `keep_tokens_from_text` re-tokenized the whole accumulated prefix once per word, and runs on every `get()`:

| text | before | after |
|---|---|---|
| 20k words | 31.7s | 0.01s |
| 200k words | ~50min | 0.07s |

A large tool result or PDF froze the run for minutes. Binary search on the word count instead.

**Uncounted tokens now counted** — `ThinkingContent.extra` holds the Anthropic block signature, echoed back verbatim on tool-use turns: measured **485 tokens per assistant turn** counted as free. The buffer believed it was under budget while the request overflowed → provider error mid-stream. Also `tool_call_id`.

**Tool schemas reserved** — `ChatMemoryBuffer.reserved_tokens`, refreshed per run by `Agent._prepare_history()`. Schemas ride along with every request but never appear in the message list, so a large MCP server could eat the whole context margin unnoticed. 203 tokens for 2 simple tools; several thousand for a 40-tool server.

**Clamp budget** — split across text parts (a message with many parts could previously reach N× the limit), and based on the budget actually available rather than the raw token limit.

## Tests

15 added, **13 fail without this change** (verified by stashing the library changes) — including end-to-end regressions that drive a real tool loop through `Agent.run()` and `run_stream()` and assert on every prompt sent.

Full suite: **275 passed, 1 skipped**.

Note for future test authors: `_mock_llm`'s `MagicMock.input_to_message_list()` returns an empty iterable, so nothing reaches memory and assertions pass vacuously. The new tests wire in the real conversion — this bit me while writing them.

## Not addressed

`_clamp_message_text` still truncates **in place** in `self.messages`, so a large tool result is shortened permanently and `get_all()` returns the truncated version. Pre-existing behaviour, avoids re-clamping every turn, but it is destructive — happy to make it copy-on-clamp if preferred.

Everything was validated against mocked LLMs; no live provider call. Image/audio/file costs remain heuristics by construction.

## Release

Patch bump to **1.0.6** (`pyproject.toml` + `uv.lock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
